### PR TITLE
Support pyfa's empty slot.

### DIFF
--- a/evepaste/parsers/eft.py
+++ b/evepaste/parsers/eft.py
@@ -16,7 +16,8 @@ EFT_LIST_RE = re.compile(r"^([\S ]+), ?([\S ]+)$")
 EFT_BLACKLIST = ['[empty high slot]',
                  '[empty low slot]',
                  '[empty medium slot]',
-                 '[empty rig slot]']
+                 '[empty rig slot]',
+                 '[empty subsystem slot]']
 
 
 def parse_eft(lines):
@@ -24,7 +25,7 @@ def parse_eft(lines):
 
     :param string paste_string: An EFT block string
     """
-    lines = [line for line in lines if line not in EFT_BLACKLIST]
+    lines = [line for line in lines if line.lower() not in EFT_BLACKLIST]
 
     if not lines:
         raise Unparsable('No valid parsable lines')


### PR DESCRIPTION
This simple change checks the line item against the blacklist after lowercasing it. EFT uses all lowercases (`[empty high slot]`), while pyfa does not (`[Empty High slot]`). Lowercasing the line before the comparison adds a layer for normalcy between these applications and any other application that generates EFT fits without thought of capitalization.

Additionally, I added 'empty subsystem' blacklist item. It's rare to copy a t3 fit without a subsystem, but both EFT and pyfa allow it and thus it should be supported.
